### PR TITLE
Fix and Update Dockerfile and glide.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ ARG GOOS=linux
 ARG GOARCH=amd64
 ARG METADATA_EXE=$CORE_METADATA_GO
 
-#RUN go get -d
 RUN GOOS=$GOOS GOARCH=$GOARCH go build -o $METADATA_EXE
 
 # Next image - Copy built Go binary into new workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,14 @@ RUN mkdir -p $GOPATH/$CORE_METADATA_GOPATH
 WORKDIR $CORE_METADATA_GOPATH
 
 # Clone repo and install dependencies
-RUN git clone $GO_CORE_METADATA_REPO . && glide install
+COPY . .
+RUN glide install
 
 ARG GOOS=linux
 ARG GOARCH=amd64
 ARG METADATA_EXE=$CORE_METADATA_GO
 
-RUN go get -d
+#RUN go get -d
 RUN GOOS=$GOOS GOARCH=$GOARCH go build -o $METADATA_EXE
 
 # Next image - Copy built Go binary into new workspace

--- a/glide.lock
+++ b/glide.lock
@@ -38,8 +38,6 @@ imports:
   subpackages:
   - bson
   - internal/json
-  - internal/sasl
-  - internal/scram
 - name: gopkg.in/yaml.v2
   version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 28336ef067c01ff6649abf801fe56ca3a6d9f7d5bbeb46cc8420c2afe0238e61
-updated: 2017-12-13T10:41:50.6074668-06:00
+hash: 5ad63c13da3416f865d2e77fbfd4b4ca7531d718e96ca3dce848bceb9f272d20
+updated: 2017-12-13T07:29:54.8871624Z
 imports:
 - name: github.com/edgexfoundry/consul-client-go
   version: 1791ee60ca82e37f0c49a93619af98430d93c5cd
 - name: github.com/edgexfoundry/core-domain-go
-  version: d575eb0459a5bb598ad364e2194b73a815ed852c
+  version: 036b01c8032ce1853b9c8edbb558109af58f4dd0
   subpackages:
   - models
 - name: github.com/edgexfoundry/support-domain-go
@@ -12,7 +12,7 @@ imports:
 - name: github.com/edgexfoundry/support-logging-client-go
   version: b9b2fa27e2fba786ecd8617915c9240fe1ac0280
 - name: github.com/edgexfoundry/support-notifications-client-go
-  version: fed937c4fc35888f1f408b16d8e9708fe12fe0f5
+  version: f7cc9662b291ec1251bf10ac8d272560ae520c1e
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
@@ -38,4 +38,8 @@ imports:
   subpackages:
   - bson
   - internal/json
+  - internal/sasl
+  - internal/scram
+- name: gopkg.in/yaml.v2
+  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
 testImports: []


### PR DESCRIPTION
Signed-off-by: Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
I think COPY local source is better than ``git clone`` as well as [core-data-go](https://github.com/edgexfoundry/core-data-go/blob/master/Dockerfile) does.
and glide.lock should be updated.

sorry my previous commit ``go get -d `` was wrong.